### PR TITLE
Fix for cart rule free shipping for matching products

### DIFF
--- a/app/code/Magento/OfflineShipping/Model/Quote/Address/FreeShipping.php
+++ b/app/code/Magento/OfflineShipping/Model/Quote/Address/FreeShipping.php
@@ -65,13 +65,12 @@ class FreeShipping implements \Magento\Quote\Model\Quote\Address\FreeShippingInt
             $itemFreeShipping = (bool)$item->getFreeShipping();
             $addressFreeShipping = $addressFreeShipping && $itemFreeShipping;
 
-            if ($addressFreeShipping && !$item->getAddress()->getFreeShipping()) {
-                $item->getAddress()->setFreeShipping(true);
-            }
-
             /** Parent free shipping we apply to all children*/
             $this->applyToChildren($item, $itemFreeShipping);
         }
+        
+        $shippingAddress->setFreeShipping($addressFreeShiping)   
+        
         return (bool)$shippingAddress->getFreeShipping();
     }
 


### PR DESCRIPTION
Fixes #14206

The previous implementation enabled free shipping on the quote by only considering the first item in the cart. This fixes that by taking all cart items into consideration.

See https://github.com/magento/magento2/issues/14206 for issue details.